### PR TITLE
Tweak and Fixes

### DIFF
--- a/Card.cpp
+++ b/Card.cpp
@@ -58,8 +58,8 @@ Order* Card::play(Deck* d, Hand* h, Territory* territoryToAttack, Territory* ter
     else if (type.compare("blockade") == 0)
     {
         //Create a neutral player
-        Player* neutralPlayer = new Player("neutral");
-        o = new Blockade(territoryToDefend, playerTerritories, neutralPlayer);
+        //Player* neutralPlayer = new Player("neutral");
+        o = new Blockade(territoryToDefend, playerTerritories);
 
     }
     else if (type.compare("airlift") == 0)

--- a/Card.h
+++ b/Card.h
@@ -3,10 +3,13 @@
 #include <stdlib.h>
 #include <string>
 #include "Orders.h"
+#include "Player.h"
 #include <iostream>
 #include <vector>
 using namespace std;
 
+class Order;
+class Player;
 //prototypes
 class Deck;
 class Card;

--- a/Map.cpp
+++ b/Map.cpp
@@ -291,9 +291,14 @@ void Territory::setAttackStatus(bool attack)
 }
 bool Territory::isAdjacentTo(Territory* t2)
 {
-    for (auto x: *t2->adjacentTerritories)
+    for (auto x: *this->adjacentTerritories)
+    {
         if (x->getTerritoryNum() == t2->getTerritoryNum())
+        {
             return true;
+        }
+
+    }
     return false;
 }
 ostream& operator <<(ostream &strm, const Territory &terr)

--- a/Orders.cpp
+++ b/Orders.cpp
@@ -6,6 +6,8 @@
 #include <time.h>
 #include "Map.h"
 #include "LoggingObserver.h"
+#include "Player.h"
+
 using std::string;
 //For storing elements
 using std::list;
@@ -468,6 +470,7 @@ Advance::Advance(Territory* targetTerritory, vector<Territory*>* ownedTerr,
     nMovedArmies = nOfArmies;
     sourceTerritory = sourceTerr;
 }
+/*
 Advance::Advance(Territory* targetTerritory, vector<Territory*>* ownedTerr, int nOfArmies,
          Territory* sourceTerr, vector<Territory*>* enemyTerrs, bool* flag):
              Order(targetTerritory, ownedTerr, "Advance")
@@ -477,6 +480,7 @@ Advance::Advance(Territory* targetTerritory, vector<Territory*>* ownedTerr, int 
     enemyTerritories = enemyTerrs;
     flagConq = flag;
 }
+*/
 //Copy Constructor
 Advance::Advance(const Advance& adv):Order(adv.targetTerritory, adv.ownedTerritories, "Advance")
 {
@@ -499,8 +503,8 @@ Advance::~Advance()
     ownedTerritories = NULL;
     nMovedArmies = 0;
     sourceTerritory = NULL;
-    flagConq = NULL;
-    enemyTerritories = NULL;
+    //flagConq = NULL;
+    //enemyTerritories = NULL;
 }
 //Stream Insertion Operator
 ostream& operator <<(ostream &strm, const Advance &adv)
@@ -523,6 +527,7 @@ void Advance::setSourceTerritory(Territory* sourceTerr)
 {
     sourceTerritory = sourceTerr;
 }
+/*
 void Advance::setFlagConqTerr(bool* flag)
 {
     flagConq = flag;
@@ -531,6 +536,7 @@ void Advance::setEnemyTerritories(vector<Territory*>* enmyTerrs)
 {
     enemyTerritories = enmyTerrs;
 }
+*/
 int Advance:: getNOfArmies()
 {
     return nMovedArmies;
@@ -658,10 +664,11 @@ void Advance::execute()
             //If there are remaining attacking armies and no more defending armies, then the territory is conquered
             if (nAttArmies > 0 && nDefArmies == 0)
             {
+                vector<Territory*>* enemyTerritories = targetTerritory->getPlayer()->getPointerToTerritories();
                 //Switches ownership of the territory
                 targetTerritory->setPlayer(sourceTerritory->getPlayer());
                 targetTerritory->setAmountOfArmies(nAttArmies);
-                if (enemyTerritories != NULL)
+                if (enemyTerritories != NULL && !enemyTerritories->empty())
                 {
                     for (vector<Territory*>::const_iterator it = enemyTerritories->begin(); it != enemyTerritories->end(); ++it)
                     {
@@ -675,8 +682,9 @@ void Advance::execute()
 
                 ownedTerritories->push_back(targetTerritory);
                 sourceTerritory->setAmountOfArmies(sourceTerritory->getAmountOfArmies()-nMovedArmies);
-                *flagConq = true;
+                sourceTerritory->getPlayer()->setFlagConqTerr(true);
             }
+
             //Otherwise, the remaining respective armies returns back to their respective territory.
             else
             {
@@ -809,28 +817,30 @@ void Bomb::execute()
 //Default Constructor
 Blockade::Blockade():Order(NULL, NULL, "Blockade")
 {
-    neutralPlayer = NULL;
+    //neutralPlayer = NULL;
 }
 //2 arg Constructor
 Blockade::Blockade(Territory* targetTerritory, vector<Territory*>* ownedTerr):Order(targetTerritory, ownedTerr, "Blockade")
 {
-    neutralPlayer = NULL;
+    //neutralPlayer = NULL;
 }
 //3 arg Constructor
+/*
 Blockade::Blockade(Territory* targetTerritory, vector<Territory*>* ownedTerr, Player* neutralPl):Order(targetTerritory, ownedTerr, "Blockade")
 {
     neutralPlayer = neutralPl;
 }
+*/
 //Copy Constructor
 Blockade::Blockade(const Blockade& block):Order(block.targetTerritory,block.ownedTerritories, "Blockade")
 {
-    neutralPlayer = block.neutralPlayer;
+    //neutralPlayer = block.neutralPlayer;
 }
 //Overload the assignment operator
 Blockade& Blockade::operator = (const Blockade& block)
 {
     Order::operator=(block);
-    this->neutralPlayer = block.neutralPlayer;
+    //this->neutralPlayer = block.neutralPlayer;
     this->orderType = "Blockade";
     return *this;
 }
@@ -858,6 +868,7 @@ Order* Blockade::duplicate()
     return new Blockade(targetTerritory,ownedTerritories);
 }
 //Setter and Getter
+/*
 Player* Blockade::getNeutralPlayer()
 {
     return neutralPlayer;
@@ -866,6 +877,7 @@ void Blockade::setNeutralPlayer(Player* nPl)
 {
     neutralPlayer = nPl;
 }
+*/
 string Blockade::stringToLog()
 {
     return "Blockade Order executed: the targetted territory is " + targetTerritory->getName();
@@ -908,7 +920,7 @@ void Blockade::execute()
         cout << "Blockade the targetted territory " << *(targetTerritory) << ". It has now 3 times the amount of armies and is neutral" << endl;
         //Executes the order
         targetTerritory->setAmountOfArmies(targetTerritory->getAmountOfArmies()*3);
-        targetTerritory->setPlayer(neutralPlayer);
+        targetTerritory->setPlayer(new Player("NEUTRAL TERRITORY"));
         for (vector<Territory*>::const_iterator it = ownedTerritories->begin(); it != ownedTerritories->end(); ++it)
         {
             if (targetTerritory == *it)
@@ -1180,7 +1192,7 @@ void Negotiate::execute()
         playersCannotAttackList[indexOfEnd][0] = callingPlayer;
         playersCannotAttackList[indexOfEnd][1] = targetPlayer;
         indexOfEnd++;
-        cout << "Negotiation have been settled between the two players" << endl;
+        cout << "Negotiation have been settled between the two players " << callingPlayer->getName() << " and " << targetPlayer->getName() << endl;
         /*
         set<Player*> setPl{};
         setPl.insert(targetPlayer);

--- a/Orders.h
+++ b/Orders.h
@@ -6,6 +6,7 @@
 #include <set>
 #include "Map.h"
 #include "LoggingObserver.h"
+#include "Player.h"
 using std::string;
 //For storing elements
 using std::list;
@@ -14,7 +15,7 @@ using std::cout;
 using std::ostream;
 
 class Player;
-
+class Territory;
 //Declarations of Order class and its subclasses
 //Declarations of Order class and its subclasses
 class Order: public Subject, public ILoggable {
@@ -124,8 +125,10 @@ public:
     //Constructors, Destructors, operator overload
     Advance();
     Advance(Territory* targetTerritory, vector<Territory*>* ownedTerr, int nOfArmies, Territory* sourceTerr);
+    /*
     Advance(Territory* targetTerritory, vector<Territory*>* ownedTerr, int nOfArmies,
              Territory* sourceTerr,vector<Territory*>* enemyTerrs, bool* flagConq);
+    */
     Advance(const Advance& adv);
     Advance& operator = (const Advance& adv);
     ~Advance();
@@ -133,8 +136,8 @@ public:
     //Setters and Getters
     void setNOfArmies(int nOA);
     void setSourceTerritory(Territory* sourceTerr);
-    void setFlagConqTerr(bool* flag);
-    void setEnemyTerritories(vector<Territory*>* enmyTerrs);
+    //void setFlagConqTerr(bool* flag);
+    //void setEnemyTerritories(vector<Territory*>* enmyTerrs);
     int getNOfArmies();
     Territory* getSourceTerritory();
     //duplicate method
@@ -150,8 +153,9 @@ private:
     Territory* sourceTerritory;
     //enemyTerritories refers to the vector of territories of which the targetTerritory belongs to
     //enemyTerritories can point to the same memory location of ownedTerritories
-    vector<Territory*>* enemyTerritories;
-    bool* flagConq;
+
+    //vector<Territory*>* enemyTerritories;
+    //bool* flagConq;
     string doPrint() const;
 
 };
@@ -180,7 +184,7 @@ class Blockade: public Order{
 public:
     Blockade();
     Blockade(Territory* targetTerritory, vector<Territory*>* ownedTerr);
-    Blockade(Territory* targetTerritory, vector<Territory*>* ownedTerr, Player* neutralPl);
+    //Blockade(Territory* targetTerritory, vector<Territory*>* ownedTerr, Player* neutralPl);
     Blockade(const Blockade& block);
     Blockade& operator = (const Blockade& block);
     ~Blockade();
@@ -190,12 +194,14 @@ public:
     bool validate();
     void execute();
     friend ostream& operator <<(ostream &strm, const Blockade &block);
+    /*
     Player* getNeutralPlayer();
     void setNeutralPlayer(Player* nPl);
+    */
     string stringToLog();
 private:
     string doPrint() const;
-    Player* neutralPlayer;
+    //Player* neutralPlayer;
 
 };
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -196,7 +196,10 @@ Hand* Player::getHand() const
 {
     return this->hand;
 }
-
+string Player::getName() const
+{
+    return name;
+}
 OrdersList* Player::getOrderList() const
 {
     return ordersList;

--- a/Player.h
+++ b/Player.h
@@ -11,6 +11,10 @@
 
 using namespace std;
 
+class Hand;
+class Order;
+class OrdersList;
+
 class Player
 {
     public:
@@ -34,7 +38,7 @@ class Player
         vector <Territory*> toAttack();
         void issueOrder();
         //Accesors and Mutators
-        string getName();
+        string getName() const;
         void setName(string newName);
         vector <Territory*>* getTerritories() const;
         void setTerritories(vector <Territory*> * terr);


### PR DESCRIPTION
-Fixed an issue with Territory::isAdjacentTo(Territory* t2). The issue being that isAdjacentTo iterates through the wrong adjacency list.
-Advance does not need the 6 arg constructor to be instantiated, nor the data field enemyTerritories and flagConqTerr. Advance::execute still removes a territory from the list of Enemy Territories and sets the flag of the conquering Player to true upon a successful conquest of a Territory. Check the changes for more details.
-Blockade does not need the 3 arg constructor nor the data field neutral player to be instantiated. Blockade::execute still does what it does, but creates a new Player object named "NEUTRAL TERRITORY".
-#include "Player.h" in Orders.h in order to have access to Player's methods
-forward declarations of classes Hand, OrdersList, Order in Player.h
-#include "Player.h" and forward declarations of classes Player, Order in Card.h
Please look at the changes.